### PR TITLE
Handle inline run styles during import and export

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,9 +148,11 @@ def formater_contenu_en_texte(contenu: List[Dict]) -> str:
         bloc_type = bloc.get("type", "")
         if bloc_type.startswith("heading"):
             niveau = bloc_type.split("_")[-1]
-            lignes_texte.append(f"{'#' * int(niveau)} {bloc.get('text', '')}")
+            texte_complet = "".join(run.get("text", "") for run in bloc.get("runs", []))
+            lignes_texte.append(f"{'#' * int(niveau)} {texte_complet}")
         elif bloc_type == "paragraph":
-            lignes_texte.append(bloc.get("text", ""))
+            texte_complet = "".join(run.get("text", "") for run in bloc.get("runs", []))
+            lignes_texte.append(texte_complet)
         elif bloc_type == "list":
             for item in bloc.get("items", []):
                 lignes_texte.append(f"* {item}")


### PR DESCRIPTION
## Summary
- Parse DOCX paragraphs into runs with individual style metadata
- Export structured responses by reconstructing paragraphs and headings from runs
- Flatten run-based content into plain text in app layer

## Testing
- `pytest`
- `python -m py_compile app.py ia_provider/exporter.py ia_provider/importer.py`


------
https://chatgpt.com/codex/tasks/task_b_68ae37f99db0832bb858528175c77116