### PR TITLE
Handle list blocks in text extraction

### DIFF
--- a/ia_provider/importer.py
+++ b/ia_provider/importer.py
@@ -160,9 +160,14 @@ def extraire_texte_de_structure(document_structure: Dict[str, List[Dict[str, Any
                 for row in bloc.get("rows", []):
                     for cell in row:
                         extraire_runs(cell)
+            elif bloc.get("type") == "list":
+                for item in bloc.get("items", []):
+                    if item.strip():
+                        texte_complet.append(item)
             elif bloc.get("runs"):
                 paragraphe = "".join(run.get("text", "") for run in bloc.get("runs", []))
-                texte_complet.append(paragraphe)
+                if paragraphe.strip():
+                    texte_complet.append(paragraphe)
 
     extraire_runs(document_structure.get("header", []))
     extraire_runs(document_structure.get("body", []))


### PR DESCRIPTION
## Summary
- include list items when extracting text from document structures
- skip empty list items and paragraphs to ensure non-empty prompts

## Testing
- `python -m py_compile ia_provider/importer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae59f54a00832b90da06e0a5103060